### PR TITLE
Branched Potential randbats: require at least 1 modded mon per team

### DIFF
--- a/data/mods/branchedpotential/formats-data.ts
+++ b/data/mods/branchedpotential/formats-data.ts
@@ -3,41 +3,49 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		randomBattleMoves: ["gigadrain", "hydropump", "leechseed", "earthpower", "substitute"],
 		tier: "OU",
 		doublesTier: "OU",
+		isModded: true,
 	},
 	pitchasaurmega: {
 		randomBattleMoves: ["gigadrain", "hydropump", "leechseed", "earthpower", "substitute"],
 		tier: "OU",
 		doublesTier: "OU",
+		isModded: true,
 	},
 	blastonoise: {
 		randomBattleMoves: ["slackoff", "scald", "flipturn", "rapidspin", "waterspout"],
 		tier: "OU",
 		doublesTier: "OU",
+		isModded: true,
 	},
 	blastonoisemega: {
 		randomBattleMoves: ["slackoff", "scald", "flipturn", "rapidspin", "waterspout", "boomburst"],
 		tier: "OU",
 		doublesTier: "OU",
+		isModded: true,
 	},
 	charodile: {
 		randomBattleMoves: ["flareblitz", "stoneedge", "earthquake", "dragondance", "thunderpunch", "stealthrock"],
 		tier: "OU",
 		doublesTier: "OU",
+		isModded: true,
 	},
 	charodilemegax: {
 		randomBattleMoves: ["flareblitz", "stoneedge", "earthquake", "dragondance", "thunderpunch", "stealthrock"],
 		tier: "OU",
 		doublesTier: "OU",
+		isModded: true,
 	},
 	charodilemegay: {
 		randomBattleMoves: ["flareblitz", "sandstorm", "stoneedge", "earthquake", "dragondance", "thunderpunch", "stealthrock"],
 		tier: "OU",
 		doublesTier: "OU",
+		isModded: true,
 	},
 	stacragus: {
 		randomBattleMoves: ["shellsmash", "dualwingbeat", "roost", "stoneedge", "stealthrock", "defog"],
 		tier: "OU",
 		doublesTier: "OU",
+		isModded: true,
 	},
 	stacraguschrysalis: {
 		tier: "Illegal",
@@ -47,21 +55,25 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		randomBattleMoves: ["toxicspikes", "toxic", "shadowball", "venoshock", "roost"],
 		tier: "OU",
 		doublesTier: "OU",
+		isModded: true,
 	},
 	hornetoxmega: {
 		randomBattleMoves: ["toxicspikes", "toxic", "shadowball", "venoshock", "roost"],
 		tier: "OU",
 		doublesTier: "OU",
+		isModded: true,
 	},
 	banshigen: {
 		randomBattleMoves: ["nastyplot", "hypervoice", "shadowball", "roost", "substitute"],
 		tier: "OU",
 		doublesTier: "OU",
+		isModded: true,
 	},
 	banshigenmega: {
 		randomBattleMoves: ["nastyplot", "hypervoice", "shadowball", "roost", "substitute"],
 		tier: "OU",
 		doublesTier: "OU",
+		isModded: true,
 	},
 	raticate: {
 		randomBattleMoves: ["protect", "facade", "stompingtantrum", "suckerpunch", "uturn", "swordsdance"],
@@ -71,11 +83,13 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		randomBattleMoves: ["softboiled", "swordsdance", "doubleedge", "bodyslam", "crunch"],
 		tier: "OU",
 		doublesTier: "OU",
+		isModded: true,
 	},	
 	ratidam: {
 		randomBattleMoves: ["hyperfang", "swordsdance", "aquajet", "liquidation", "stompingtantrum"],
 		tier: "OU",
 		doublesTier: "OU",	
+		isModded: true,
 	},
 	fearow: {
 		tier: "NFE",
@@ -84,11 +98,13 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		randomBattleMoves: ["irondefense", "roost", "bodypress", "acrobatics", "defog"],
 		tier: "OU",
 		doublesTier: "OU",
+		isModded: true,
 	},
 	storrow: {
 		randomBattleMoves: ["swordsdance", "drillrun", "playrough", "bravebird", "uturn"],
 		tier: "OU",
 		doublesTier: "OU",
+		isModded: true,
 	},
 	arbok: {
 		randomBattleMoves: ["coil", "gunkshot", "suckerpunch", "aquatail", "earthquake", "rest"],
@@ -98,6 +114,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		randomBattleMoves: ["coil", "gunkshot", "poltergeist", "aquatail", "earthquake", "rest"],
 		tier: "OU",
 		doublesTier: "OU",
+		isModded: true,
 	},
 	phankyrrevealed: {
 		tier: "Illegal",
@@ -107,26 +124,31 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		randomBattleMoves: ["nastyplot", "surf", "sludgewave", "earthpower", "flamethrower"],
 		tier: "OU",
 		doublesTier: "OU",
+		isModded: true,
 	},
 	mountoswine: {
 		randomBattleMoves: ["auroraveil", "blizzard", "earthpower", "freezedry", "stealthrock"],
 		tier: "OU",
 		doublesTier: "OU",
+		isModded: true,
 	},
 	lapidour: {
 		randomBattleMoves: ["stealthrock", "moonblast", "hiddenpowerground", "powergem", "moonlight", "darkpulse"],
 		tier: "OU",
 		doublesTier: "OU",
+		isModded: true,
 	},
 	lapidourmega: {
 		randomBattleMoves: ["stealthrock", "moonblast", "hiddenpowerground", "powergem", "moonlight", "darkpulse"],
 		tier: "OU",
 		doublesTier: "OU",
+		isModded: true,
 	},	
 	lamprecut: {
 		randomBattleMoves: ["drainpunch", "plasmafists", "aquatail", "coil", "icepunch"],
 		tier: "OU",
 		doublesTier: "OU",
+		isModded: true,
 	},
 	durant: {
 		randomBattleMoves: ["honeclaws", "ironhead", "xscissor", "rockslide", "superpower"],
@@ -136,11 +158,13 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		randomBattleMoves: ["firstimpression", "uturn", "knockoff", "stoneedge", "xscissor", "ironhead"],
 		tier: "OU",
 		doublesTier: "OU",
+		isModded: true,
 	},
 	durandurant: {
 		randomBattleMoves: ["bugbuzz", "overdrive", "nastyplot", "hiddenpowerice", "voltswitch"],
 		tier: "OU",
 		doublesTier: "OU",
+		isModded: true,
 	},
 	dragalge: {
 		randomBattleMoves: ["dracometeor", "sludgewave", "focusblast", "scald", "hiddenpowerfire", "toxicspikes", "dragonpulse", "flipturn"],
@@ -150,11 +174,13 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		randomBattleMoves: ["dracometeor", "sludgewave", "hydropump", "hiddenpowerground"],
 		tier: "OU",
 		doublesTier: "OU",
+		isModded: true,
 	},
 	thermalge: {
 		randomBattleMoves: ["sludgewave", "flamethrower", "sleeppowder", "sludgebomb", "substitute"],
 		tier: "OU",
 		doublesTier: "OU",
+		isModded: true,
 	},
 	parelp: {
 		tier: "LC",
@@ -167,6 +193,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		randomBattleMoves: ["rapidspin", "protect", "leechseed", "synthesis", "toxic", "knockoff", "substitute"],
 		tier: "OU",
 		doublesTier: "OU",
+		isModded: true,
 	},
 	lusopass: {
 		randomBattleMoves: ["poltergeist", "earthquake", "knockoff", "ironhead", "substitute"],
@@ -176,6 +203,7 @@ export const FormatsData: {[k: string]: SpeciesFormatsData} = {
 		randomBattleMoves: ["aurasphere", "flashcannon", "darkpulse", "shadowball", "waterpulse", "nastyplot"],
 		tier: "OU",
 		doublesTier: "OU",
+		isModded: true,
 	},
 	//
 	//

--- a/data/mods/branchedpotential/random-teams.ts
+++ b/data/mods/branchedpotential/random-teams.ts
@@ -1663,6 +1663,7 @@ export class RandomTeams {
 		const teamDetails: RandomTeamsTypes.TeamDetails = {};
 		
 		let megaCount = 0; 
+		let hasModded = false;
 
 		// We make at most two passes through the potential Pokemon pool when creating a team - if the first pass doesn't
 		// result in a team of six Pokemon we perform a second iteration relaxing as many restrictions as possible.
@@ -1713,7 +1714,7 @@ export class RandomTeams {
 				const types = species.types;
 				const typeCombo = types.slice().sort().join();
 				const isMega = (species.name.endsWith('-Mega') || species.name.endsWith('-Mega-Y') || species.name.endsWith('-Mega-X'));
-				
+				const modded = species.isModded;
 
 				if (restrict) {
 					// Limit one Pokemon per tier, two for Monotype
@@ -1743,6 +1744,13 @@ export class RandomTeams {
 						else megaCount++;
 					} else {
 						if (megaCount === 0 && pokemon.length === 5) continue;
+					}
+					
+					//Require at least one modded Pokemon per team
+					if (modded) {
+						hasModded = true;
+					} else {
+						if (hasModded === false && pokemon.length === 5) continue;
 					}
 				}
 


### PR DESCRIPTION
I clicked through about 5 battles and it seemed to hold up just fine? I can't see it having problems with more extensive testing since it's pretty simple code. 

This does require that any future fakemon added to this format include the line "isModded: true," in their entry in formats-data.ts, which isn't _suuuuper_ ideal, but it's simpler than having it run full checks vs the unmodded Pokedex. If you're the one who's going to be updating the mod with new random battle sets for newly added mons, you can also add that line to their entries along with the move selections so the random team builder picks it up. 

You can check the diffs to see what was changed here but it's basically just in the same spot and functionality as the bit of code that requires at least 1 Mega per team. If we are adding a modded mon to the team, set the "hasModded" variable we established earlier to "true"; if by the 6th pokemon in our team we have not yet set "hasModded" to "true", just keep generating new sets until it gives us a Pokemon flagged with "isModded". 

Including extra custom fields in formats-data.ts like this is a great hack for passing information to the random team generator, there's a lot you can do with it. 